### PR TITLE
Fix `.in()` error in `NumberAdjuster.es`

### DIFF
--- a/src/libs/NumberAdjuster.es
+++ b/src/libs/NumberAdjuster.es
@@ -147,7 +147,7 @@ export default class NumberAdjuster extends AdjusterInterface
 		}
 		if(this._in.includes(values.adjustedValue))
 		{
-			return false;
+			return true;
 		}
 
 		const cause = CAUSE.IN;


### PR DESCRIPTION
* finish adjustment when input value matches in `in`.