### PR TITLE
U: throw first error when both onError and onErrorAll are null in adjustData()

### DIFF
--- a/src/libs/adjustData.es
+++ b/src/libs/adjustData.es
@@ -15,6 +15,11 @@ function adjustData(data, adjusters, onError = null, onErrorAll = null)
 	{
 		const adjustedValue = adjusters[key].adjust(data[key], (err) =>
 		{
+			if(onError === null && onErrorAll === null)
+			{
+				throw err;
+			}
+
 			errs[key] = err;
 			if(onError !== null)
 			{


### PR DESCRIPTION
## Change Specifications
* throw first error when both `onError` and `onErrorAll` are null in `adjustData()`