### PR TITLE
C: `AdjusterError.prototype.key` indicates a key name that caused err…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `adjuster.string().trim()`
 * `adjuster.stringArray().eachTrim()`
 
+### Changed
+* `AdjusterError.prototype.key` indicates a key name that caused error; only filled in `adjuster.adjust()`, otherwise `null`
+* error handler for `adjuster.adjust()` needs only 1 parameters `err`; `key` is in `err.key`
+
 ### Others
 * use changelog
 * reference in README

--- a/src/libs/AdjusterError.es
+++ b/src/libs/AdjusterError.es
@@ -15,5 +15,6 @@ export default class AdjusterError extends Error
 		this.name = "AdjusterError";
 		this.cause = cause;
 		this.value = value;
+		this.key = null;
 	}
 }

--- a/src/libs/adjust.es
+++ b/src/libs/adjust.es
@@ -15,6 +15,7 @@ function adjust(data, constraints, onError = null, onErrorAll = null)
 	{
 		const adjustedValue = constraints[key].adjust(data[key], (err) =>
 		{
+			err.key = key;
 			if(onError === null && onErrorAll === null)
 			{
 				throw err;
@@ -23,7 +24,7 @@ function adjust(data, constraints, onError = null, onErrorAll = null)
 			errs[key] = err;
 			if(onError !== null)
 			{
-				return onError(key, err);
+				return onError(err);
 			}
 		});
 
@@ -42,7 +43,6 @@ function adjust(data, constraints, onError = null, onErrorAll = null)
 
 /**
  * @callback adjust~OnError
- * @param {string} key
  * @param {AdjusterError} err
  */
 /**

--- a/test/index.test.es
+++ b/test/index.test.es
@@ -1,13 +1,14 @@
 import adjuster from "index";
 
 {
-	describe("data", testData);
+	describe("adjust", testAdjust);
+	describe("error", testError);
 }
 
 /**
  * test for adjust multiple variables
  */
-function testData()
+function testAdjust()
 {
 	it("should be adjusted", () =>
 	{
@@ -51,6 +52,42 @@ function testData()
 		};
 
 		const adjusted = adjuster.adjust(input, constraints);
+		expect(adjusted).toEqual(expected);
+	});
+}
+
+/**
+ * error handling
+ */
+function testError()
+{
+	it("should be adjusted", () =>
+	{
+		const constraints = {
+			id: adjuster.number().minValue(1),
+			name: adjuster.string().maxLength(16, true),
+			email: adjuster.email(),
+		};
+		const input = {
+			id: 0, // error! (>= 1)
+			name: "", // error! (empty string is not allowed)
+			email: "john@example.com", // OK
+		};
+		const expected = {
+			id: 100,
+			email: "john@example.com",
+		};
+
+		const adjusted = adjuster.adjust(input, constraints, (err) =>
+		{
+			switch(err.key)
+			{
+			case "id":
+				return 100;
+			default:
+				return undefined;
+			}
+		});
 		expect(adjusted).toEqual(expected);
 	});
 }


### PR DESCRIPTION
### Changed
* `AdjusterError.prototype.key` indicates a key name that caused error; only filled in `adjuster.adjust()`, otherwise `null`
* error handler for `adjuster.adjust()` needs only 1 parameters `err`; `key` is in `err.key`