### PR TITLE
C: limit number's range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* `adjuster.number()` limits input value Limit the value to `Number.MIN_SAFE_INTEGER` or more and `Number.MAX_SAFE_INTEGER` or less
 
 ## [0.9.0] - 2018-06-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -413,10 +413,15 @@ Limit minimum value to `value`.
 
 If input value is less than `value`, `adjust()` method returns `value` (if `adjust` is truthy) or causes `AdjusterError` (falsy; default).
 
+By default, `value` equals `Number.MIN_SAFE_INTEGER`.
+
 ##### examples
 
 ```javascript
 // should be OK
+assert.strictEqual(
+    adjuster.number().adjust(Number.MIN_SAFE_INTEGER),
+    Number.MIN_SAFE_INTEGER);
 assert.strictEqual(
     adjuster.number().minValue(1).adjust(1),
     1);
@@ -428,6 +433,9 @@ assert.strictEqual(
 
 // should cause errors
 assert.throws(
+    () => adjuster.number().adjust(Number.MIN_SAFE_INTEGER - 1),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MIN_VALUE));
+assert.throws(
     () => adjuster.number().minValue(1).adjust(0),
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MIN_VALUE));
 ```
@@ -437,10 +445,15 @@ Limit maximum value to `value`.
 
 If input value is greater than `value`, `adjust()` method returns `value` (if `adjust` is truthy) or causes `AdjusterError` (falsy; default).
 
+By default, `value` equals `Number.MAX_SAFE_INTEGER`.
+
 ##### examples
 
 ```javascript
 // should be OK
+assert.strictEqual(
+    adjuster.number().adjust(Number.MAX_SAFE_INTEGER),
+    Number.MAX_SAFE_INTEGER);
 assert.strictEqual(
     adjuster.number().maxValue(1).adjust(1),
     1);
@@ -451,6 +464,9 @@ assert.strictEqual(
     100);
 
 // should cause errors
+assert.throws(
+    () => adjuster.number().adjust(Number.MAX_SAFE_INTEGER + 1),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MAX_VALUE));
 assert.throws(
     () => adjuster.number().maxValue(100).adjust(101),
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MAX_VALUE));

--- a/src/libs/decorators/number/maxValue.es
+++ b/src/libs/decorators/number/maxValue.es
@@ -15,7 +15,7 @@ export default AdjusterBase.decoratorBuilder(_adjust)
  */
 function _init(params)
 {
-	params.flag = false;
+	params.value = Number.MAX_SAFE_INTEGER;
 }
 
 /**
@@ -27,7 +27,6 @@ function _init(params)
  */
 function _featureMaxValue(params, value, adjust = false)
 {
-	params.flag = true;
 	params.value = value;
 	params.adjust = adjust;
 }
@@ -41,10 +40,6 @@ function _featureMaxValue(params, value, adjust = false)
  */
 function _adjust(params, values)
 {
-	if(!params.flag)
-	{
-		return false;
-	}
 	if(values.adjusted <= params.value)
 	{
 		return false;

--- a/src/libs/decorators/number/minValue.es
+++ b/src/libs/decorators/number/minValue.es
@@ -15,7 +15,7 @@ export default AdjusterBase.decoratorBuilder(_adjust)
  */
 function _init(params)
 {
-	params.flag = false;
+	params.value = Number.MIN_SAFE_INTEGER;
 }
 
 /**
@@ -27,7 +27,6 @@ function _init(params)
  */
 function _featureMinValue(params, value, adjust = false)
 {
-	params.flag = true;
 	params.value = value;
 	params.adjust = adjust;
 }
@@ -41,10 +40,6 @@ function _featureMinValue(params, value, adjust = false)
  */
 function _adjust(params, values)
 {
-	if(!params.flag)
-	{
-		return false;
-	}
 	if(values.adjusted >= params.value)
 	{
 		return false;

--- a/test/adjusters/number.test.es
+++ b/test/adjusters/number.test.es
@@ -142,6 +142,8 @@ function testMinValue()
 {
 	it("should be OK", () =>
 	{
+		expect(adjuster.number()
+			.adjust(Number.MIN_SAFE_INTEGER)).toEqual(Number.MIN_SAFE_INTEGER);
 		expect(adjuster.number().minValue(10)
 			.adjust(10)).toEqual(10);
 	});
@@ -152,6 +154,11 @@ function testMinValue()
 	});
 	it("should cause error(s)", () =>
 	{
+		expect(() =>
+		{
+			adjuster.number()
+				.adjust(Number.MIN_SAFE_INTEGER - 1);
+		}).toThrow(adjuster.CAUSE.MIN_VALUE);
 		expect(() =>
 		{
 			adjuster.number().minValue(10)
@@ -167,6 +174,8 @@ function testMaxValue()
 {
 	it("should be OK", () =>
 	{
+		expect(adjuster.number()
+			.adjust(Number.MAX_SAFE_INTEGER)).toEqual(Number.MAX_SAFE_INTEGER);
 		expect(adjuster.number().maxValue(100)
 			.adjust(100)).toEqual(100);
 	});
@@ -177,6 +186,11 @@ function testMaxValue()
 	});
 	it("should cause error(s)", () =>
 	{
+		expect(() =>
+		{
+			adjuster.number()
+				.adjust(Number.MAX_SAFE_INTEGER + 1);
+		}).toThrow(adjuster.CAUSE.MAX_VALUE);
 		expect(() =>
 		{
 			adjuster.number().maxValue(100)


### PR DESCRIPTION
### Changed
* `adjuster.number()` limits input value Limit the value to `Number.MIN_SAFE_INTEGER` or more and `Number.MAX_SAFE_INTEGER` or less