### PR TITLE
FIX: number rejects boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * `adjuster.STRING_PATTERN`, regular expressions for `adjuster.string().pattern()`
 
+### Fixed
+* `adjuster.number().adjust(true)` throws an error; should return `1`
+
 ## [0.11.0] - 2018-07-16
 ### Added
 * `adjuster.number().acceptSpecialFormats()`

--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ assert.strictEqual(
 assert.strictEqual(
     adjuster.number().adjust("-123"),
     -123);
+assert.strictEqual(
+    adjuster.number().adjust(true),
+    1);
+assert.strictEqual(
+    adjuster.number().adjust(false),
+    0);
 
 // should cause error
 assert.strictEqual( // catch error by callback function (that returns a value from adjust() method)
@@ -337,6 +343,9 @@ assert.strictEqual( // catch error by callback function (that returns a value fr
     10);
 assert.throws( // ... or try-catch syntax
     () => adjuster.number().adjust("abc"),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TYPE));
+assert.throws(
+    () => adjuster.number().adjust("true"),
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TYPE));
 ```
 

--- a/src/libs/decorators/number/acceptSpecialFormats.es
+++ b/src/libs/decorators/number/acceptSpecialFormats.es
@@ -40,6 +40,11 @@ function _acceptSpecialFormats(params)
  */
 function _adjust(params, values)
 {
+	if(typeof values.adjusted !== "string")
+	{
+		return false;
+	}
+
 	if(params.flag)
 	{
 		return false;

--- a/test/adjusters/number.test.es
+++ b/test/adjusters/number.test.es
@@ -35,6 +35,12 @@ function testType()
 		expect(adjuster.number()
 			.adjust("-789")).toEqual(-789);
 
+		expect(adjuster.number()
+			.adjust(true)).toEqual(1);
+
+		expect(adjuster.number()
+			.adjust(false)).toEqual(0);
+
 		expect(adjuster.number().acceptSpecialFormats()
 			.adjust("1e+2")).toEqual(100);
 


### PR DESCRIPTION
* `adjuster.number().adjust(true)` causes error; should be equal to 1
