### PR TITLE
FIX: method names `eachIn()` is old in JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* `adjuster.numberArray().eachIn()` in JSDoc (should be `adjuster.numberArray().eachOnly()`)
+* `adjuster.stringArray().eachIn()` in JSDoc (should be `adjuster.stringArray().eachOnly()`)
 
 ## [0.12.0] - 2018-07-18
 ### Added

--- a/src/adjusters/numberArray.es
+++ b/src/adjusters/numberArray.es
@@ -126,7 +126,7 @@ class NumberArrayAdjuster extends AdjusterBase
 	/**
 	 * accept only specified values for each elements
 	 * @method
-	 * @name NumberArrayAdjuster#eachIn
+	 * @name NumberArrayAdjuster#eachOnly
 	 * @param {...number} values values to be accepted
 	 * @return {NumberArrayAdjuster}
 	 */

--- a/src/adjusters/stringArray.es
+++ b/src/adjusters/stringArray.es
@@ -126,7 +126,7 @@ class StringArrayAdjuster extends AdjusterBase
 	/**
 	 * accept only specified values for each elements
 	 * @method
-	 * @name StringArrayAdjuster#eachIn
+	 * @name StringArrayAdjuster#eachOnly
 	 * @param {...string} values values to be accepted
 	 * @return {StringArrayAdjuster}
 	 */


### PR DESCRIPTION
* `eachIn()` should be `eachOnly()`
