### PR TITLE
CHANGE: string() type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * cause an error `adjuster.CAUSE.TYPE` instead of  `adjuster.CAUSE.NOT_OBJECT`
+* reject array and object in `adjuster.string()`
+* in `numericString`, when `.joinArray()` is not called and an array is passed, cause an error `adjuster.CAUSE.TYPE` instead of `adjuster.CAUSE.PATTERN`
 
 ### Deleted
 * `adjuster.numberArray()` - use `adjuster.array()` instead

--- a/README.md
+++ b/README.md
@@ -1299,7 +1299,7 @@ assert.strictEqual(
 // should cause error
 assert.throws(
     () => adjuster.numericString().adjust(["1234", "5678"]),
-    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.PATTERN));
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TYPE));
 ```
 
 #### `minLength(length)`

--- a/src/libs/decorators/string/type.mjs
+++ b/src/libs/decorators/string/type.mjs
@@ -1,5 +1,5 @@
 import {CAUSE} from "../../constants";
-import {isString} from "../../types";
+import {isString, isArray, isObject} from "../../types";
 import AdjusterBase from "../../AdjusterBase";
 import AdjusterError from "../../AdjusterError";
 
@@ -47,6 +47,12 @@ function _adjust(params, values, keyStack)
 
 	// strict check
 	if(params.flagStrict)
+	{
+		AdjusterError.raise(CAUSE.TYPE, values, keyStack);
+	}
+
+	// array or object cannot be convert to string
+	if(isArray(values.adjusted) || isObject(values.adjusted))
 	{
 		AdjusterError.raise(CAUSE.TYPE, values, keyStack);
 	}

--- a/test/adjusters/numericString.test.mjs
+++ b/test/adjusters/numericString.test.mjs
@@ -67,7 +67,7 @@ function testJoinArray()
 		{
 			adjuster.numericString()
 				.adjust(["1111", "2222", "3333", "4444"]);
-		}).toThrow(adjuster.CAUSE.PATTERN);
+		}).toThrow(adjuster.CAUSE.TYPE);
 	});
 }
 

--- a/test/adjusters/string.test.mjs
+++ b/test/adjusters/string.test.mjs
@@ -44,6 +44,18 @@ function testType()
 	{
 		expect(() =>
 		{
+			adjuster.string()
+				.adjust([]);
+		}).toThrow(adjuster.CAUSE.TYPE);
+
+		expect(() =>
+		{
+			adjuster.string()
+				.adjust({});
+		}).toThrow(adjuster.CAUSE.TYPE);
+
+		expect(() =>
+		{
 			adjuster.string().strict()
 				.adjust(0);
 		}).toThrow(adjuster.CAUSE.TYPE);


### PR DESCRIPTION
* CHANGE: reject array and object in `adjuster.string()`
* CHANGE: in `numericString`, when `.joinArray()` is not called and an array is passed, cause an error `adjuster.CAUSE.TYPE` instead of `adjuster.CAUSE.PATTERN`
