### PR TITLE
FIX: usage of parseInt()

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -122,7 +122,7 @@ rules: # https://eslint.org/docs/rules/
   no-continue: 'off'
   no-div-regex: error
   no-duplicate-imports: error
-  no-else-return: error
+  no-else-return: 'off'
   no-empty-function: 'off'
   no-eq-null: error
   no-eval: error

--- a/src/decorators/number/type.mjs
+++ b/src/decorators/number/type.mjs
@@ -160,7 +160,14 @@ function _toNumber(params, value)
 	// parse as integer
 	if(params.flagIntegerAdjust)
 	{
-		return parseInt(adjustedValue, 10);
+		if(adjustedValue > 0)
+		{
+			return Math.floor(adjustedValue);
+		}
+		else
+		{
+			return Math.ceil(adjustedValue);
+		}
 	}
 
 	// not an integer


### PR DESCRIPTION
* FIX: `parseInt()` accepts only string!
