### PR TITLE
FIX: fix the parameter type of adjuster.numericString().maxLength()

### DIFF
--- a/test/adjusters/numericString.test.mjs
+++ b/test/adjusters/numericString.test.mjs
@@ -135,7 +135,7 @@ function testMaxLength()
 	{
 		expect(adjuster.numericString().maxLength(4, true)
 			.adjust("11111")).toEqual("1111");
-		expect(adjuster.numericString().maxLength(4, 1).separatedBy("-")
+		expect(adjuster.numericString().maxLength(4, true).separatedBy("-")
 			.adjust("111-222")).toEqual("1112");
 	});
 	it("should cause error(s)", () =>


### PR DESCRIPTION
* second argument of `adjuster.numericString().maxLength()` must be Boolean
