### PR TITLE
CHANGE: type of pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* `adjuster.string().pattern()` and `adjuster.email().pattern()` accept only RegExp (reject string)
 
 ## [1.0.0-rc.1] - 2018-08-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -964,7 +964,7 @@ interface StringAdjuster {
     only(...values: string[]): this;
     minLength(length: number): this;
     maxLength(length: number, adjust?: boolean /* = false */): this;
-    pattern(pattern: string|RegExp): this;
+    pattern(pattern: RegExp): this;
 }
 ```
 
@@ -1159,9 +1159,6 @@ You can also use `adjuster.STRING.PATTERN` constants
 assert.deepStrictEqual(
     adjuster.string().pattern(/^Go+gle$/).adjust("Gogle"),
     "Gogle");
-assert.deepStrictEqual(
-    adjuster.string().pattern("^Go+gle$").adjust("Google"),
-    "Google");
 assert.deepStrictEqual(
     adjuster.string().pattern(adjuster.STRING.PATTERN.URI).adjust("https://example.com/path/to/resource?name=value#hash"),
     "https://example.com/path/to/resource?name=value#hash");
@@ -1653,7 +1650,7 @@ interface EmailAdjuster {
     acceptNull(value?: string|null /* = null */): this;
     acceptEmptyString(value?: string|null /* = null */): this;
     trim(): this;
-    pattern(pattern: string|RegExp): this;
+    pattern(pattern: RegExp): this;
 }
 ```
 

--- a/src/decorators/array/type.mjs
+++ b/src/decorators/array/type.mjs
@@ -25,7 +25,7 @@ function _init(params)
 /**
  * accept string and set separator
  * @param {Object} params parameters
- * @param {string|RegExp} separator separator
+ * @param {Separator} separator separator
  * @returns {void}
  */
 function _featureSeparatedBy(params, separator)

--- a/src/decorators/numericString/separatedBy.mjs
+++ b/src/decorators/numericString/separatedBy.mjs
@@ -20,7 +20,7 @@ function _init(params)
 /**
  * ignore separator
  * @param {Object} params parameters
- * @param {Pattern} separator separator
+ * @param {Separator} separator separator
  * @returns {void}
  */
 function _featureSeparatedBy(params, separator)

--- a/src/decorators/string/pattern.mjs
+++ b/src/decorators/string/pattern.mjs
@@ -1,4 +1,3 @@
-import {isString} from "../../libs/types";
 import {CAUSE} from "../../libs/constants";
 import AdjusterBase from "../../libs/AdjusterBase";
 import AdjusterError from "../../libs/AdjusterError";
@@ -11,35 +10,37 @@ export default AdjusterBase.decoratorBuilder(_adjust)
 	.build();
 
 /**
+ * @typedef {Object} _TypeParamsStringPattern
+ * @property {boolean} flag
+ * @property {RegExp} pattern
+ */
+
+/**
  * init
- * @param {Object} params parameters
+ * @param {_TypeParamsStringPattern} params parameters
  * @returns {void}
  */
 function _init(params)
 {
 	params.flag = false;
+	params.pattern = null;
 }
 
 /**
  * specify acceptable pattern by regular expression
- * @param {Object} params parameters
- * @param {Pattern} pattern acceptable pattern(regular expression); string or RegExp
+ * @param {_TypeParamsStringPattern} params parameters
+ * @param {RegExp} pattern acceptable pattern(regular expression)
  * @returns {void}
  */
 function _featurePattern(params, pattern)
 {
-	if(isString(pattern))
-	{
-		pattern = new RegExp(pattern);
-	}
-
 	params.flag = true;
 	params.pattern = pattern;
 }
 
 /**
  * adjust
- * @param {Object} params parameters
+ * @param {_TypeParamsStringPattern} params parameters
  * @param {DecoratorValues} values original / adjusted values
  * @param {Key[]} keyStack path to key that caused error
  * @returns {boolean} end adjustment

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -208,10 +208,10 @@ interface StringAdjuster extends AdjusterBase<string>
 
 	/**
 	 * specify acceptable pattern by regular expression
-	 * @param pattern acceptable pattern(regular expression); string or RegExp
+	 * @param pattern acceptable pattern(regular expression)
 	 * @returns chainable instance
 	 */
-	pattern(pattern: Pattern): this
+	pattern(pattern: RegExp): this
 }
 
 interface NumericStringAdjuster extends AdjusterBase<string>
@@ -248,7 +248,7 @@ interface NumericStringAdjuster extends AdjusterBase<string>
 	 * @param separator separator
 	 * @returns chainable instance
 	 */
-	separatedBy(separator: Pattern): this
+	separatedBy(separator: Separator): this
 
 	/**
 	 * set min-length
@@ -364,10 +364,10 @@ interface EmailAdjuster extends AdjusterBase<string>
 
 	/**
 	 * specify acceptable pattern by regular expression
-	 * @param pattern acceptable pattern(regular expression); string or RegExp
+	 * @param pattern acceptable pattern(regular expression)
 	 * @returns chainable instance
 	 */
-	pattern(pattern: Pattern): this
+	pattern(pattern: RegExp): this
 }
 
 interface ArrayAdjuster extends AdjusterBase<any[]>
@@ -399,7 +399,7 @@ interface ArrayAdjuster extends AdjusterBase<any[]>
 	 * @param separator separator
 	 * @returns chainable instance
 	 */
-	separatedBy(separator: Pattern): this
+	separatedBy(separator: Separator): this
 
 	/**
 	 * convert to array, if not
@@ -467,7 +467,7 @@ type Input = null | boolean | number | string | any[] | Object
 type Constraints = { [name: string]: AdjusterBase<any> }
 type ErrorHandler<T = any> = (err: AdjusterError | null) => T | void
 type Key = string | number
-type Pattern = RegExp | string
+type Separator = RegExp | string
 
 type ConstantsCause = {
 	TYPE: string,


### PR DESCRIPTION
* CHANGE: `adjuster.string().pattern()` and `adjuster.email().pattern()` accept only RegExp (reject string)
