### PR TITLE
generics for TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* `adjust()` and `object()` returns type `any`, accept generics for type-safe
+* `array()` returns type `any[]`, accepts generics for type-safe
+
 ## [1.0.1] - 2018-12-04
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-* `adjust()` and `object()` returns type `any`, accept generics for type-safe
-* `array()` returns type `any[]`, accepts generics for type-safe
+* `adjuster.adjust()` and `adjuster.object()` returns type `any`, accept generics for type-safe
+* `adjuster.array()` returns type `any[]`, accepts generics for type-safe
 
 ## [1.0.1] - 2018-12-04
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ For more information, see [string](#string).
 
 ```typescript
 namespace adjuster {
-    export declare function adjust(data: any, constraints: Object, onError?: (err: AdjusterError | null) => any): Object;
+    export declare function adjust<T = any>(data: any, constraints: Object, onError?: (err: AdjusterError | null) => any): T;
 }
 ```
 
@@ -345,6 +345,26 @@ const expected = {
 
 const adjusted = adjuster.adjust(input, constraints);
 assert.deepStrictEqual(adjusted, expected);
+```
+
+In TypeScript, use Generics for type-safe.
+
+```typescript
+interface Parameters {
+    foo: number
+    bar: string
+}
+
+const constraints = {
+    foo: adjuster.number(),
+    bar: adjuster.string(),
+};
+const input = {
+    foo: "12345",
+    bar: "abcde",
+};
+
+const adjusted = adjuster.adjust<Parameters>(input, constraints);
 ```
 
 ###### error handling 1
@@ -1634,12 +1654,12 @@ assert.throws(
 
 ```typescript
 namespace adjuster {
-    export declare function array(): ArrayAdjuster;
+    export declare function array<T = any[]>(): ArrayAdjuster;
 }
 
-interface ArrayAdjuster {
+interface ArrayAdjuster<T> {
     // adjustment method
-    adjust(value: any, onError?: (err: AdjusterError) => Array | void): Array;
+    adjust(value: any, onError?: (err: AdjusterError) => Array | void): T;
 
     // feature methods (chainable)
     default(value: Array): this;
@@ -1855,12 +1875,12 @@ assert.throws(
 
 ```typescript
 namespace adjuster {
-    export declare function object(): ObjectAdjuster;
+    export declare function object<T = any>(): ObjectAdjuster;
 }
 
-interface ObjectAdjuster {
+interface ObjectAdjuster<T> {
     // adjustment method
-    adjust(value: any, onError?: (err: AdjusterError) => Object | void): Object;
+    adjust(value: any, onError?: (err: AdjusterError) => Object | void): T;
 
     // feature methods (chainable)
     default(value: Object): this;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,15 +10,15 @@ declare namespace adjuster
 	 * @param [onError] error handler
 	 * @returns adjusted data
 	 */
-	function adjust(data: Input, constraints: Constraints, onError?: ErrorHandler): CollectionObject
+	function adjust<T = any>(data: Input, constraints: Constraints, onError?: ErrorHandler): T
 
 	function boolean(): BooleanAdjuster
 	function number(): NumberAdjuster
 	function string(): StringAdjuster
 	function numericString(): NumericStringAdjuster
 	function email(): EmailAdjuster
-	function array(): ArrayAdjuster
-	function object(): ObjectAdjuster
+	function array<T = any[]>(): ArrayAdjuster<T>
+	function object<T = any>(): ObjectAdjuster<T>
 
 	const CAUSE: ConstantsCause;
 	const STRING: ConstantsStringOptions;
@@ -308,7 +308,7 @@ interface EmailAdjuster extends AdjusterBase<string>
 	pattern(pattern: RegExp): this
 }
 
-interface ArrayAdjuster extends AdjusterBase<CollectionArray>
+interface ArrayAdjuster<T> extends AdjusterBase<T>
 {
 	/**
 	 * set default value; enable to omit
@@ -368,7 +368,7 @@ interface ArrayAdjuster extends AdjusterBase<CollectionArray>
 	each(adjusterInstance: AdjusterBase<any>, ignoreEachErrors?: boolean): this
 }
 
-interface ObjectAdjuster extends AdjusterBase<CollectionObject>
+interface ObjectAdjuster<T> extends AdjusterBase<T>
 {
 	/**
 	 * set default value; enable to omit


### PR DESCRIPTION
* `adjuster.adjust()` and `adjuster.object()` returns type `any`, accept generics for type-safe
* `adjuster.array()` returns type `any[]`, accepts generics for type-safe
