### PR TITLE
return type of adjuster.array()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* `adjuster.array<T>()` returns type `T[]`
+
 ## [1.1.0] - 2018-12-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1654,12 +1654,12 @@ assert.throws(
 
 ```typescript
 namespace adjuster {
-    export declare function array<T = any[]>(): ArrayAdjuster;
+    export declare function array<T = any>(): ArrayAdjuster;
 }
 
 interface ArrayAdjuster<T> {
     // adjustment method
-    adjust(value: any, onError?: (err: AdjusterError) => Array | void): T;
+    adjust(value: any, onError?: (err: AdjusterError) => Array | void): T[];
 
     // feature methods (chainable)
     default(value: Array): this;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ declare namespace adjuster
 	function string(): StringAdjuster
 	function numericString(): NumericStringAdjuster
 	function email(): EmailAdjuster
-	function array<T = any[]>(): ArrayAdjuster<T>
+	function array<T = any>(): ArrayAdjuster<T>
 	function object<T = any>(): ObjectAdjuster<T>
 
 	const CAUSE: ConstantsCause;
@@ -308,7 +308,7 @@ interface EmailAdjuster extends AdjusterBase<string>
 	pattern(pattern: RegExp): this
 }
 
-interface ArrayAdjuster<T> extends AdjusterBase<T>
+interface ArrayAdjuster<T> extends AdjusterBase<T[]>
 {
 	/**
 	 * set default value; enable to omit


### PR DESCRIPTION
* `adjuster.array<T>()` returns type `T[]`
