### PR TITLE
convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* `adjuster.number().transform()`
-* `adjuster.string().transform()`
-* `adjuster.numericString().transform()`
+* `adjuster.number().convert()`
+* `adjuster.string().convert()`
+* `adjuster.numericString().convert()`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* `adjuster.number().transform()`
+* `adjuster.string().transform()`
+* `adjuster.numericString().transform()`
+
+### Deprecated
+
+* `adjuster.number().map()`
+* `adjuster.string().map()`
+* `adjuster.numericString().map()`
+
 ## [1.3.1] - 2019-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -729,8 +729,8 @@ interface NumberAdjuster {
     only(...values: number[]): this;
     minValue(value: number, adjust?: boolean /* = false */): this;
     maxValue(value: number, adjust?: boolean /* = false */): this;
-    transform(transformer: (value: number, fail: () => never) => number): this;
-    // deprecated; use transform()
+    convert(converter: (value: number, fail: () => never) => number): this;
+    // deprecated; use convert()
     map(mapper: (value: number, fail: () => never) => number): this;
 }
 ```
@@ -1013,24 +1013,24 @@ assert.throws(
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MAX_VALUE));
 ```
 
-#### `transform(transformer)` / `map(mapper)`
+#### `convert(converter)` / `map(mapper)`
 
-Transform input value to another value.
+Convert input value into another value.
 
-WARNING; `map()` is deprecated. use `transform()`.
+WARNING; `map()` is deprecated. use `convert()`.
 
 ##### examples
 
 ```javascript
 // should be adjusted
 assert.strictEqual(
-    adjuster.number().transform(value => value + 1).adjust(100)
+    adjuster.number().convert(value => value + 1).adjust(100)
     101);
 
 // should cause errors
 assert.throws(
-    () => adjuster.number().transform((value, fail) => fail()).adjust(100),
-    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TRANSFORM));
+    () => adjuster.number().convert((value, fail) => fail()).adjust(100),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.CONVERT));
 ```
 
 ### string
@@ -1056,8 +1056,8 @@ interface StringAdjuster {
     minLength(length: number): this;
     maxLength(length: number, adjust?: boolean /* = false */): this;
     pattern(pattern: RegExp): this;
-    transform(transformer: (value: string, fail: () => never) => string): this;
-    // deprecated; use transform()
+    convert(converter: (value: string, fail: () => never) => string): this;
+    // deprecated; use convert()
     map(mapper: (value: string, fail: () => never) => string): this;
 }
 ```
@@ -1277,24 +1277,24 @@ assert.throws(
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.PATTERN));
 ```
 
-#### `transform(transformer)` / `map(mapper)`
+#### `convert(converter)` / `map(mapper)`
 
-Transform input value to another value.
+Convert input value into another value.
 
-WARNING; `map()` is deprecated. use `transform()`.
+WARNING; `map()` is deprecated. use `convert()`.
 
 ##### examples
 
 ```javascript
 // should be adjusted
 assert.strictEqual(
-    adjuster.string().transform(value => value + value).adjust("abc")
+    adjuster.string().convert(value => value + value).adjust("abc")
     "abcabc");
 
 // should cause errors
 assert.throws(
-    () => adjuster.string().transform((value, fail) => fail()).adjust("abc"),
-    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TRANSFORM));
+    () => adjuster.string().convert((value, fail) => fail()).adjust("abc"),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.CONVERT));
 ```
 
 ### numeric string
@@ -1319,8 +1319,8 @@ interface NumericStringAdjuster {
     minLength(length: number): this;
     maxLength(length: number, adjust?: boolean /* = false */): this;
     checksum(algorithm: string): this;
-    transform(transformer: (value: string, fail: () => never) => string): this;
-    // deprecated; use transform()
+    convert(converter: (value: string, fail: () => never) => string): this;
+    // deprecated; use convert()
     map(mapper: (value: string, fail: () => never) => string): this;
 }
 ```
@@ -1528,24 +1528,24 @@ assert.throws(
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.CHECKSUM));
 ```
 
-#### `transform(transformer)` / `map(mapper)`
+#### `convert(converter)` / `map(mapper)`
 
-Transform input value to another value.
+Convert input value into another value.
 
-WARNING; `map()` is deprecated. use `transform()`.
+WARNING; `map()` is deprecated. use `convert()`.
 
 ##### examples
 
 ```javascript
 // should be adjusted
 assert.strictEqual(
-    adjuster.numericString().transform(value => value.substr(0, 4) + "-" + value.substr(4)).adjust("12345678")
+    adjuster.numericString().convert(value => value.substr(0, 4) + "-" + value.substr(4)).adjust("12345678")
     "1234-5678");
 
 // should cause errors
 assert.throws(
-    () => adjuster.numericString().transform((value, fail) => fail()).adjust("abc"),
-    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TRANSFORM));
+    () => adjuster.numericString().convert((value, fail) => fail()).adjust("abc"),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.CONVERT));
 ```
 
 ### email

--- a/README.md
+++ b/README.md
@@ -729,6 +729,8 @@ interface NumberAdjuster {
     only(...values: number[]): this;
     minValue(value: number, adjust?: boolean /* = false */): this;
     maxValue(value: number, adjust?: boolean /* = false */): this;
+    transform(transformer: (value: number, fail: () => never) => number): this;
+    // deprecated; use transform()
     map(mapper: (value: number, fail: () => never) => number): this;
 }
 ```
@@ -1011,22 +1013,24 @@ assert.throws(
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MAX_VALUE));
 ```
 
-#### `map(mapper)`
+#### `transform(transformer)` / `map(mapper)`
 
-Map input value to another value.
+Transform input value to another value.
+
+WARNING; `map()` is deprecated. use `transform()`.
 
 ##### examples
 
 ```javascript
 // should be adjusted
 assert.strictEqual(
-    adjuster.number().map(value => value + 1).adjust(100)
+    adjuster.number().transform(value => value + 1).adjust(100)
     101);
 
 // should cause errors
 assert.throws(
-    () => adjuster.number().map((value, fail) => fail()).adjust(100),
-    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MAP));
+    () => adjuster.number().transform((value, fail) => fail()).adjust(100),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TRANSFORM));
 ```
 
 ### string
@@ -1052,6 +1056,8 @@ interface StringAdjuster {
     minLength(length: number): this;
     maxLength(length: number, adjust?: boolean /* = false */): this;
     pattern(pattern: RegExp): this;
+    transform(transformer: (value: string, fail: () => never) => string): this;
+    // deprecated; use transform()
     map(mapper: (value: string, fail: () => never) => string): this;
 }
 ```
@@ -1271,22 +1277,24 @@ assert.throws(
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.PATTERN));
 ```
 
-#### `map(mapper)`
+#### `transform(transformer)` / `map(mapper)`
 
-Map input value to another value.
+Transform input value to another value.
+
+WARNING; `map()` is deprecated. use `transform()`.
 
 ##### examples
 
 ```javascript
 // should be adjusted
 assert.strictEqual(
-    adjuster.number().map(value => value + value).adjust("abc")
+    adjuster.string().transform(value => value + value).adjust("abc")
     "abcabc");
 
 // should cause errors
 assert.throws(
-    () => adjuster.number().map((value, fail) => fail()).adjust("abc"),
-    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MAP));
+    () => adjuster.string().transform((value, fail) => fail()).adjust("abc"),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TRANSFORM));
 ```
 
 ### numeric string
@@ -1311,6 +1319,8 @@ interface NumericStringAdjuster {
     minLength(length: number): this;
     maxLength(length: number, adjust?: boolean /* = false */): this;
     checksum(algorithm: string): this;
+    transform(transformer: (value: string, fail: () => never) => string): this;
+    // deprecated; use transform()
     map(mapper: (value: string, fail: () => never) => string): this;
 }
 ```
@@ -1518,22 +1528,24 @@ assert.throws(
     (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.CHECKSUM));
 ```
 
-#### `map(mapper)`
+#### `transform(transformer)` / `map(mapper)`
 
-Map input value to another value.
+Transform input value to another value.
+
+WARNING; `map()` is deprecated. use `transform()`.
 
 ##### examples
 
 ```javascript
 // should be adjusted
 assert.strictEqual(
-    adjuster.number().map(value => value.substr(0, 4) + "-" + value.substr(4)).adjust("12345678")
+    adjuster.numericString().transform(value => value.substr(0, 4) + "-" + value.substr(4)).adjust("12345678")
     "1234-5678");
 
 // should cause errors
 assert.throws(
-    () => adjuster.number().map((value, fail) => fail()).adjust("abc"),
-    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.MAP));
+    () => adjuster.numericString().transform((value, fail) => fail()).adjust("abc"),
+    (err) => (err.name === "AdjusterError" && err.cause === adjuster.CAUSE.TRANSFORM));
 ```
 
 ### email

--- a/src/adjusters/number.mjs
+++ b/src/adjusters/number.mjs
@@ -4,7 +4,7 @@ import Default from "../decorators/default";
 import AcceptNull from "../decorators/acceptNull";
 import AcceptEmptyString from "../decorators/acceptEmptyString";
 import Only from "../decorators/only";
-import Transform from "../decorators/transform";
+import Convert from "../decorators/convert";
 import Type from "../decorators/number/type";
 import MinValue from "../decorators/number/minValue";
 import MaxValue from "../decorators/number/maxValue";
@@ -21,7 +21,7 @@ export default () =>
 /**
  * adjuster for number
  */
-@Transform
+@Convert
 @MaxValue
 @MinValue
 @Only

--- a/src/adjusters/number.mjs
+++ b/src/adjusters/number.mjs
@@ -4,7 +4,7 @@ import Default from "../decorators/default";
 import AcceptNull from "../decorators/acceptNull";
 import AcceptEmptyString from "../decorators/acceptEmptyString";
 import Only from "../decorators/only";
-import Map from "../decorators/map";
+import Transform from "../decorators/transform";
 import Type from "../decorators/number/type";
 import MinValue from "../decorators/number/minValue";
 import MaxValue from "../decorators/number/maxValue";
@@ -21,7 +21,7 @@ export default () =>
 /**
  * adjuster for number
  */
-@Map
+@Transform
 @MaxValue
 @MinValue
 @Only

--- a/src/adjusters/numericString.mjs
+++ b/src/adjusters/numericString.mjs
@@ -3,7 +3,7 @@ import AdjusterBase from "../libs/AdjusterBase";
 import Default from "../decorators/default";
 import AcceptNull from "../decorators/acceptNull";
 import AcceptEmptyString from "../decorators/acceptEmptyString";
-import Transform from "../decorators/transform";
+import Convert from "../decorators/convert";
 import Type from "../decorators/string/type";
 import MinLength from "../decorators/string/minLength";
 import MaxLength from "../decorators/string/maxLength";
@@ -24,7 +24,7 @@ export default () =>
 /**
  * adjuster for numeric string
  */
-@Transform
+@Convert
 @Checksum
 @MaxLength
 @MinLength

--- a/src/adjusters/numericString.mjs
+++ b/src/adjusters/numericString.mjs
@@ -3,7 +3,7 @@ import AdjusterBase from "../libs/AdjusterBase";
 import Default from "../decorators/default";
 import AcceptNull from "../decorators/acceptNull";
 import AcceptEmptyString from "../decorators/acceptEmptyString";
-import Map from "../decorators/map";
+import Transform from "../decorators/transform";
 import Type from "../decorators/string/type";
 import MinLength from "../decorators/string/minLength";
 import MaxLength from "../decorators/string/maxLength";
@@ -24,7 +24,7 @@ export default () =>
 /**
  * adjuster for numeric string
  */
-@Map
+@Transform
 @Checksum
 @MaxLength
 @MinLength

--- a/src/adjusters/string.mjs
+++ b/src/adjusters/string.mjs
@@ -4,7 +4,7 @@ import Default from "../decorators/default";
 import AcceptNull from "../decorators/acceptNull";
 import AcceptEmptyString from "../decorators/acceptEmptyString";
 import Only from "../decorators/only";
-import Map from "../decorators/map";
+import Transform from "../decorators/transform";
 import Type from "../decorators/string/type";
 import Trim from "../decorators/string/trim";
 import MinLength from "../decorators/string/minLength";
@@ -23,7 +23,7 @@ export default () =>
 /**
  * adjuster for string
  */
-@Map
+@Transform
 @Pattern
 @MaxLength
 @MinLength

--- a/src/adjusters/string.mjs
+++ b/src/adjusters/string.mjs
@@ -4,7 +4,7 @@ import Default from "../decorators/default";
 import AcceptNull from "../decorators/acceptNull";
 import AcceptEmptyString from "../decorators/acceptEmptyString";
 import Only from "../decorators/only";
-import Transform from "../decorators/transform";
+import Convert from "../decorators/convert";
 import Type from "../decorators/string/type";
 import Trim from "../decorators/string/trim";
 import MinLength from "../decorators/string/minLength";
@@ -23,7 +23,7 @@ export default () =>
 /**
  * adjuster for string
  */
-@Transform
+@Convert
 @Pattern
 @MaxLength
 @MinLength

--- a/src/decorators/convert.mjs
+++ b/src/decorators/convert.mjs
@@ -5,8 +5,8 @@ import AdjusterError from "../libs/AdjusterError";
 export default AdjusterBase.decoratorBuilder(_adjust)
 	.init(_init)
 	.features({
-		map: _featureTransform,
-		transform: _featureTransform,
+		convert: _featureConvert,
+		map: _featureConvert, // deprecated
 	})
 	.build();
 
@@ -17,17 +17,17 @@ export default AdjusterBase.decoratorBuilder(_adjust)
 
 /**
  * @package
- * @callback Transformer
- * @param {*} value value to transform
+ * @callback Converter
+ * @param {*} value value to convert
  * @param {Fail} fail callback on fail
- * @returns {*} transformed value
+ * @returns {*} converted value
  */
 
 /**
  * @package
  * @typedef {Params} Params-Only
  * @property {boolean} flag
- * @property {Mapper | null} maper
+ * @property {Converter | null} converter
  */
 
 /**
@@ -38,19 +38,19 @@ export default AdjusterBase.decoratorBuilder(_adjust)
 function _init(params)
 {
 	params.flag = false;
-	params.mapper = null;
+	params.converter = null;
 }
 
 /**
- * accept only specified values
+ * conversion values
  * @param {Params-Only} params parameters
- * @param {Transformer} mapper mapper function
+ * @param {Converter} converter conversion function
  * @returns {void}
  */
-function _featureTransform(params, mapper)
+function _featureConvert(params, converter)
 {
 	params.flag = true;
-	params.mapper = mapper;
+	params.converter = converter;
 }
 
 /**
@@ -68,9 +68,9 @@ function _adjust(params, values, keyStack)
 		return false;
 	}
 
-	values.adjusted = params.mapper(values.adjusted, () =>
+	values.adjusted = params.converter(values.adjusted, () =>
 	{
-		AdjusterError.raise(CAUSE.TRANSFORM, values, keyStack);
+		AdjusterError.raise(CAUSE.CONVERT, values, keyStack);
 	});
 	return false;
 }

--- a/src/decorators/convert.mjs
+++ b/src/decorators/convert.mjs
@@ -25,14 +25,14 @@ export default AdjusterBase.decoratorBuilder(_adjust)
 
 /**
  * @package
- * @typedef {Params} Params-Only
+ * @typedef {Params} Params-Convert
  * @property {boolean} flag
  * @property {Converter | null} converter
  */
 
 /**
  * init
- * @param {Params-Only} params parameters
+ * @param {Params-Convert} params parameters
  * @returns {void}
  */
 function _init(params)
@@ -43,7 +43,7 @@ function _init(params)
 
 /**
  * conversion values
- * @param {Params-Only} params parameters
+ * @param {Params-Convert} params parameters
  * @param {Converter} converter conversion function
  * @returns {void}
  */
@@ -55,7 +55,7 @@ function _featureConvert(params, converter)
 
 /**
  * adjust
- * @param {Params-Only} params parameters
+ * @param {Params-Convert} params parameters
  * @param {Decorator-Values} values original / adjusted values
  * @param {Key[]} keyStack path to key that caused error
  * @returns {boolean} end adjustment

--- a/src/decorators/transform.mjs
+++ b/src/decorators/transform.mjs
@@ -5,7 +5,8 @@ import AdjusterError from "../libs/AdjusterError";
 export default AdjusterBase.decoratorBuilder(_adjust)
 	.init(_init)
 	.features({
-		map: _featureMap,
+		map: _featureTransform,
+		transform: _featureTransform,
 	})
 	.build();
 
@@ -16,10 +17,10 @@ export default AdjusterBase.decoratorBuilder(_adjust)
 
 /**
  * @package
- * @callback Mapper
- * @param {*} value value to map
+ * @callback Transformer
+ * @param {*} value value to transform
  * @param {Fail} fail callback on fail
- * @returns {*} mapped value
+ * @returns {*} transformed value
  */
 
 /**
@@ -43,10 +44,10 @@ function _init(params)
 /**
  * accept only specified values
  * @param {Params-Only} params parameters
- * @param {Mapper} mapper mapper function
+ * @param {Transformer} mapper mapper function
  * @returns {void}
  */
-function _featureMap(params, mapper)
+function _featureTransform(params, mapper)
 {
 	params.flag = true;
 	params.mapper = mapper;
@@ -69,7 +70,7 @@ function _adjust(params, values, keyStack)
 
 	values.adjusted = params.mapper(values.adjusted, () =>
 	{
-		AdjusterError.raise(CAUSE.MAP, values, keyStack);
+		AdjusterError.raise(CAUSE.TRANSFORM, values, keyStack);
 	});
 	return false;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -152,17 +152,17 @@ interface NumberAdjuster extends AdjusterBase<number>
 	maxValue(value: number, adjust?: boolean): this
 
 	/**
-	 * transforming
-	 * @param transformer transforming function
+	 * conversion
+	 * @param converter conversion function
 	 * @returns chainable instance
 	 */
-	transform(transformer: (value: number, fail: () => never) => number): this
+	convert(converter: (value: number, fail: () => never) => number): this
 
 	/**
 	 * mapping
 	 * @param mapper mapping function
 	 * @returns chainable instance
-	 * @deprecated use transform()
+	 * @deprecated use convert()
 	 */
 	map(mapper: (value: number, fail: () => never) => number): this
 }
@@ -232,17 +232,17 @@ interface StringAdjuster extends AdjusterBase<string>
 	pattern(pattern: RegExp): this
 
 	/**
-	 * transforming
-	 * @param transformer transforming function
+	 * conversion
+	 * @param converter conversion function
 	 * @returns chainable instance
 	 */
-	transform(transformer: (value: string, fail: () => never) => string): this
+	convert(converter: (value: string, fail: () => never) => string): this
 
 	/**
 	 * mapping
 	 * @param mapper mapping function
 	 * @returns chainable instance
-	 * @deprecated use transform()
+	 * @deprecated use convert()
 	 */
 	map(mapper: (value: string, fail: () => never) => string): this
 }
@@ -306,17 +306,17 @@ interface NumericStringAdjuster extends AdjusterBase<string>
 	checksum(algorithm: string): this
 
 	/**
-	 * transforming
-	 * @param transformer transforming function
+	 * conversion
+	 * @param converter conversion function
 	 * @returns chainable instance
 	 */
-	transform(transformer: (value: string, fail: () => never) => string): this
+	convert(converter: (value: string, fail: () => never) => string): this
 
 	/**
 	 * mapping
 	 * @param mapper mapping function
 	 * @returns chainable instance
-	 * @deprecated use transform()
+	 * @deprecated use convert()
 	 */
 	map(mapper: (value: string, fail: () => never) => string): this
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -463,6 +463,8 @@ type ConstantsCause = {
 	NULL: string,
 	EMPTY: string,
 	ONLY: string,
+	MAP: string, // deprecated; use CONVERT
+	CONVERT: string,
 
 	MIN_VALUE: string,
 	MAX_VALUE: string,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -152,9 +152,17 @@ interface NumberAdjuster extends AdjusterBase<number>
 	maxValue(value: number, adjust?: boolean): this
 
 	/**
+	 * transforming
+	 * @param transformer transforming function
+	 * @returns chainable instance
+	 */
+	transform(transformer: (value: number, fail: () => never) => number): this
+
+	/**
 	 * mapping
 	 * @param mapper mapping function
 	 * @returns chainable instance
+	 * @deprecated use transform()
 	 */
 	map(mapper: (value: number, fail: () => never) => number): this
 }
@@ -224,9 +232,17 @@ interface StringAdjuster extends AdjusterBase<string>
 	pattern(pattern: RegExp): this
 
 	/**
+	 * transforming
+	 * @param transformer transforming function
+	 * @returns chainable instance
+	 */
+	transform(transformer: (value: string, fail: () => never) => string): this
+
+	/**
 	 * mapping
 	 * @param mapper mapping function
 	 * @returns chainable instance
+	 * @deprecated use transform()
 	 */
 	map(mapper: (value: string, fail: () => never) => string): this
 }
@@ -290,9 +306,17 @@ interface NumericStringAdjuster extends AdjusterBase<string>
 	checksum(algorithm: string): this
 
 	/**
+	 * transforming
+	 * @param transformer transforming function
+	 * @returns chainable instance
+	 */
+	transform(transformer: (value: string, fail: () => never) => string): this
+
+	/**
 	 * mapping
 	 * @param mapper mapping function
 	 * @returns chainable instance
+	 * @deprecated use transform()
 	 */
 	map(mapper: (value: string, fail: () => never) => string): this
 }

--- a/src/libs/constants.mjs
+++ b/src/libs/constants.mjs
@@ -9,7 +9,8 @@ export const CAUSE = {
 	NULL: "null",
 	EMPTY: "empty",
 	ONLY: "only",
-	MAP: "map",
+	MAP: "transform", // deprecated; use TRANSFORM
+	TRANSFORM: "transform",
 
 	MIN_VALUE: "min-value",
 	MAX_VALUE: "max-value",

--- a/src/libs/constants.mjs
+++ b/src/libs/constants.mjs
@@ -9,8 +9,8 @@ export const CAUSE = {
 	NULL: "null",
 	EMPTY: "empty",
 	ONLY: "only",
-	MAP: "transform", // deprecated; use TRANSFORM
-	TRANSFORM: "transform",
+	MAP: "convert", // deprecated; use CONVERT
+	CONVERT: "convert",
 
 	MIN_VALUE: "min-value",
 	MAX_VALUE: "max-value",

--- a/test/adjusters/number.test.mjs
+++ b/test/adjusters/number.test.mjs
@@ -8,7 +8,7 @@ import adjuster from "adjuster"; // eslint-disable-line import/no-unresolved
 	describe("only", testOnly);
 	describe("minValue", testMinValue);
 	describe("maxValue", testMaxValue);
-	describe("map", testMap);
+	describe("transform", testTransform);
 }
 
 /**
@@ -325,25 +325,25 @@ function testMaxValue()
 }
 
 /**
- * mapping
+ * transforming
  * @returns {void}
  */
-function testMap()
+function testTransform()
 {
 	it("should be incremented", () =>
 	{
-		expect(adjuster.number().map(mapper)
+		expect(adjuster.number().transform(transformer)
 			.adjust(100)).toEqual(101);
 
-		expect(adjuster.number().map(mapper)
+		expect(adjuster.number().transform(transformer)
 			.adjust("1")).toEqual(2);
 
 		/**
-		 * mapping function
-		 * @param {number} value value to map
-		 * @returns {number} mapped value
+		 * transforming function
+		 * @param {number} value value to transform
+		 * @returns {number} transformed value
 		 */
-		function mapper(value)
+		function transformer(value)
 		{
 			return value + 1;
 		}
@@ -352,17 +352,17 @@ function testMap()
 	{
 		expect(() =>
 		{
-			adjuster.number().map(mapper)
+			adjuster.number().transform(transformer)
 				.adjust(100);
-		}).toThrow(adjuster.CAUSE.MAP);
+		}).toThrow(adjuster.CAUSE.TRANSFORM);
 
 		/**
-		 * mapping function
-		 * @param {number} value value to map
+		 * transforming function
+		 * @param {number} value value to transform
 		 * @param {Function} fail callback on fail
-		 * @returns {number} mapped value
+		 * @returns {number} transformed value
 		 */
-		function mapper(value, fail)
+		function transformer(value, fail)
 		{
 			fail();
 		}

--- a/test/adjusters/number.test.mjs
+++ b/test/adjusters/number.test.mjs
@@ -8,7 +8,7 @@ import adjuster from "adjuster"; // eslint-disable-line import/no-unresolved
 	describe("only", testOnly);
 	describe("minValue", testMinValue);
 	describe("maxValue", testMaxValue);
-	describe("transform", testTransform);
+	describe("convert", testConvert);
 }
 
 /**
@@ -325,25 +325,25 @@ function testMaxValue()
 }
 
 /**
- * transforming
+ * conversion
  * @returns {void}
  */
-function testTransform()
+function testConvert()
 {
 	it("should be incremented", () =>
 	{
-		expect(adjuster.number().transform(transformer)
+		expect(adjuster.number().convert(converter)
 			.adjust(100)).toEqual(101);
 
-		expect(adjuster.number().transform(transformer)
+		expect(adjuster.number().convert(converter)
 			.adjust("1")).toEqual(2);
 
 		/**
-		 * transforming function
-		 * @param {number} value value to transform
-		 * @returns {number} transformed value
+		 * conversion function
+		 * @param {number} value value to convert
+		 * @returns {number} converted value
 		 */
-		function transformer(value)
+		function converter(value)
 		{
 			return value + 1;
 		}
@@ -352,17 +352,17 @@ function testTransform()
 	{
 		expect(() =>
 		{
-			adjuster.number().transform(transformer)
+			adjuster.number().convert(converter)
 				.adjust(100);
-		}).toThrow(adjuster.CAUSE.TRANSFORM);
+		}).toThrow(adjuster.CAUSE.CONVERT);
 
 		/**
-		 * transforming function
-		 * @param {number} value value to transform
+		 * conversion function
+		 * @param {number} value value to convert
 		 * @param {Function} fail callback on fail
-		 * @returns {number} transformed value
+		 * @returns {number} converted value
 		 */
-		function transformer(value, fail)
+		function converter(value, fail)
 		{
 			fail();
 		}

--- a/test/adjusters/numericString.test.mjs
+++ b/test/adjusters/numericString.test.mjs
@@ -11,7 +11,7 @@ import adjuster from "adjuster"; // eslint-disable-line import/no-unresolved
 	describe("checksum (Luhn)", testChecksumLuhn);
 	describe("checksum (Modulus 10 / Weight 3:1)", testChecksumModulus10Weight31);
 	describe("checksum (Others)", testChecksumOthers);
-	describe("map", testMap);
+	describe("transform", testTransform);
 }
 
 /**
@@ -241,21 +241,21 @@ function testChecksumOthers()
  * checksum - Luhn algorithm
  * @returns {void}
  */
-function testMap()
+function testTransform()
 {
 	it("should be separated", () =>
 	{
-		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).map(mapper)
+		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).transform(transformer)
 			.adjust("4111111111111111")).toEqual("4111-1111-1111-1111");
-		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).map(mapper)
+		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).transform(transformer)
 			.adjust("378282246310005")).toEqual("3782-8224-6310-005");
 
 		/**
-		 * mapping function
-		 * @param {string} value value to map
-		 * @returns {string} mapped value
+		 * transforming function
+		 * @param {string} value value to transform
+		 * @returns {string} transformed value
 		 */
-		function mapper(value)
+		function transformer(value)
 		{
 			// separate per 4 characters
 			const parts = [];
@@ -271,17 +271,17 @@ function testMap()
 	{
 		expect(() =>
 		{
-			adjuster.numericString().map(mapper)
+			adjuster.numericString().transform(transformer)
 				.adjust("12345");
-		}).toThrow(adjuster.CAUSE.MAP);
+		}).toThrow(adjuster.CAUSE.TRANSFORM);
 
 		/**
-		 * mapping function
-		 * @param {string} value value to map
+		 * transforming function
+		 * @param {string} value value to transform
 		 * @param {Function} fail callback on fail
-		 * @returns {string} mapped value
+		 * @returns {string} transformed value
 		 */
-		function mapper(value, fail)
+		function transformer(value, fail)
 		{
 			fail();
 		}

--- a/test/adjusters/numericString.test.mjs
+++ b/test/adjusters/numericString.test.mjs
@@ -11,7 +11,7 @@ import adjuster from "adjuster"; // eslint-disable-line import/no-unresolved
 	describe("checksum (Luhn)", testChecksumLuhn);
 	describe("checksum (Modulus 10 / Weight 3:1)", testChecksumModulus10Weight31);
 	describe("checksum (Others)", testChecksumOthers);
-	describe("transform", testTransform);
+	describe("convert", testConvert);
 }
 
 /**
@@ -241,21 +241,21 @@ function testChecksumOthers()
  * checksum - Luhn algorithm
  * @returns {void}
  */
-function testTransform()
+function testConvert()
 {
 	it("should be separated", () =>
 	{
-		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).transform(transformer)
+		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).convert(converter)
 			.adjust("4111111111111111")).toEqual("4111-1111-1111-1111");
-		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).transform(transformer)
+		expect(adjuster.numericString().checksum(adjuster.NUMERIC_STRING.CHECKSUM_ALGORITHM.CREDIT_CARD).convert(converter)
 			.adjust("378282246310005")).toEqual("3782-8224-6310-005");
 
 		/**
-		 * transforming function
-		 * @param {string} value value to transform
-		 * @returns {string} transformed value
+		 * conversion function
+		 * @param {string} value value to convert
+		 * @returns {string} converted value
 		 */
-		function transformer(value)
+		function converter(value)
 		{
 			// separate per 4 characters
 			const parts = [];
@@ -271,17 +271,17 @@ function testTransform()
 	{
 		expect(() =>
 		{
-			adjuster.numericString().transform(transformer)
+			adjuster.numericString().convert(converter)
 				.adjust("12345");
-		}).toThrow(adjuster.CAUSE.TRANSFORM);
+		}).toThrow(adjuster.CAUSE.CONVERT);
 
 		/**
-		 * transforming function
-		 * @param {string} value value to transform
+		 * conversion function
+		 * @param {string} value value to convert
 		 * @param {Function} fail callback on fail
-		 * @returns {string} transformed value
+		 * @returns {string} converted value
 		 */
-		function transformer(value, fail)
+		function converter(value, fail)
 		{
 			fail();
 		}

--- a/test/adjusters/string.test.mjs
+++ b/test/adjusters/string.test.mjs
@@ -10,7 +10,7 @@ import adjuster from "adjuster"; // eslint-disable-line import/no-unresolved
 	describe("minLength", testMinLength);
 	describe("maxLength", testMaxLength);
 	describe("pattern", testPattern);
-	describe("map", testMap);
+	describe("transform", testTransform);
 }
 
 /**
@@ -508,19 +508,19 @@ function testPatternOthers()
  * mapping
  * @returns {void}
  */
-function testMap()
+function testTransform()
 {
 	it("should be repeated", () =>
 	{
-		expect(adjuster.string().map(mapper)
+		expect(adjuster.string().transform(transformer)
 			.adjust("abc")).toEqual("abcabc");
 
 		/**
-		 * mapping function
-		 * @param {string} value value to map
-		 * @returns {string} mapped value
+		 * transforming function
+		 * @param {string} value value to transform
+		 * @returns {string} transformed value
 		 */
-		function mapper(value)
+		function transformer(value)
 		{
 			return `${value}${value}`;
 		}
@@ -529,17 +529,17 @@ function testMap()
 	{
 		expect(() =>
 		{
-			adjuster.string().map(mapper)
+			adjuster.string().transform(transformer)
 				.adjust("abc");
-		}).toThrow(adjuster.CAUSE.MAP);
+		}).toThrow(adjuster.CAUSE.TRANSFORM);
 
 		/**
-		 * mapping function
-		 * @param {string} value value to map
+		 * transforming function
+		 * @param {string} value value to transform
 		 * @param {Function} fail callback on fail
-		 * @returns {string} mapped value
+		 * @returns {string} transformed value
 		 */
-		function mapper(value, fail)
+		function transformer(value, fail)
 		{
 			fail();
 		}

--- a/test/adjusters/string.test.mjs
+++ b/test/adjusters/string.test.mjs
@@ -10,7 +10,7 @@ import adjuster from "adjuster"; // eslint-disable-line import/no-unresolved
 	describe("minLength", testMinLength);
 	describe("maxLength", testMaxLength);
 	describe("pattern", testPattern);
-	describe("transform", testTransform);
+	describe("convert", testConvert);
 }
 
 /**
@@ -508,19 +508,19 @@ function testPatternOthers()
  * mapping
  * @returns {void}
  */
-function testTransform()
+function testConvert()
 {
 	it("should be repeated", () =>
 	{
-		expect(adjuster.string().transform(transformer)
+		expect(adjuster.string().convert(converter)
 			.adjust("abc")).toEqual("abcabc");
 
 		/**
-		 * transforming function
-		 * @param {string} value value to transform
-		 * @returns {string} transformed value
+		 * conversion function
+		 * @param {string} value value to convert
+		 * @returns {string} converted value
 		 */
-		function transformer(value)
+		function converter(value)
 		{
 			return `${value}${value}`;
 		}
@@ -529,17 +529,17 @@ function testTransform()
 	{
 		expect(() =>
 		{
-			adjuster.string().transform(transformer)
+			adjuster.string().convert(converter)
 				.adjust("abc");
-		}).toThrow(adjuster.CAUSE.TRANSFORM);
+		}).toThrow(adjuster.CAUSE.CONVERT);
 
 		/**
-		 * transforming function
-		 * @param {string} value value to transform
+		 * conversion function
+		 * @param {string} value value to convert
 		 * @param {Function} fail callback on fail
-		 * @returns {string} transformed value
+		 * @returns {string} converted value
 		 */
-		function transformer(value, fail)
+		function converter(value, fail)
 		{
 			fail();
 		}


### PR DESCRIPTION
### Added

* `adjuster.number().transform()`
* `adjuster.string().transform()`
* `adjuster.numericString().transform()`

### Deprecated

* `adjuster.number().map()`
* `adjuster.string().map()`
* `adjuster.numericString().map()`