### PR TITLE
Feature/date under ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* `vs.date()` accepts under milliseconds
+
 ## [4.0.0-rc.2] - 2022-12-11
 
 ### Added

--- a/dist-deno/appliers/date/iso8601.ts
+++ b/dist-deno/appliers/date/iso8601.ts
@@ -1,7 +1,7 @@
 import { RULE, ValueSchemaError } from "../../exporter.ts";
 import { isString, Key, Values } from "../../libs/types.ts";
-const PATTERN_WITH_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/;
-const PATTERN_WITHOUT_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d{1,3})?)?$/;
+const PATTERN_WITH_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d+)?)?(Z|[+-]\d{2}:\d{2})$/;
+const PATTERN_WITHOUT_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d+)?)?$/;
 interface Iso8601 {
     /** default timezone when timezone is omitted from input value */
     defaultTimezone?: string;

--- a/src/appliers/date/iso8601.ts
+++ b/src/appliers/date/iso8601.ts
@@ -2,8 +2,8 @@ import {RULE, ValueSchemaError} from "../../exporter";
 
 import {isString, Key, Values} from "../../libs/types";
 
-const PATTERN_WITH_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/;
-const PATTERN_WITHOUT_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d{1,3})?)?$/;
+const PATTERN_WITH_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d+)?)?(Z|[+-]\d{2}:\d{2})$/;
+const PATTERN_WITHOUT_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d+)?)?$/;
 
 interface Iso8601
 {

--- a/test/schemas/date.test.ts
+++ b/test/schemas/date.test.ts
@@ -40,6 +40,20 @@ function testType(): void
 			vs.date().applyTo("2020-01-01T00:00+09:00")
 		).toEqual(new Date("2019-12-31T15:00:00.000Z"));
 
+		// milliseconds
+		expect(
+			vs.date().applyTo("2000-01-02T03:04:05.6Z")
+		).toEqual(new Date("2000-01-02T03:04:05.600Z"));
+		expect(
+			vs.date().applyTo("2000-01-02T03:04:05.67Z")
+		).toEqual(new Date("2000-01-02T03:04:05.670Z"));
+		expect(
+			vs.date().applyTo("2000-01-02T03:04:05.678Z")
+		).toEqual(new Date("2000-01-02T03:04:05.678Z"));
+		expect(
+			vs.date().applyTo("2000-01-02T03:04:05.6789Z")
+		).toEqual(new Date("2000-01-02T03:04:05.678Z"));
+
 		// empty object
 		expect(
 			vs.date({}).applyTo("2020-01-01T00:00:00.000Z")
@@ -57,6 +71,10 @@ function testType(): void
 		expect(() =>
 		{
 			vs.date().applyTo("abc");
+		}).toThrow(vs.RULE.PATTERN);
+		expect(() =>
+		{
+			vs.date().applyTo("2020-01-01T00:00:00.Z");
 		}).toThrow(vs.RULE.PATTERN);
 
 		// invalid date


### PR DESCRIPTION
### Added

* `vs.date()` accepts under milliseconds